### PR TITLE
Removed the first tomcat instance kill, catalina stop should do it's work

### DIFF
--- a/files/instance/bin/catalina.sh
+++ b/files/instance/bin/catalina.sh
@@ -390,7 +390,7 @@ elif [ "$1" = "stop" ] ; then
 
   shift
 
-  SLEEP=5
+  SLEEP=10
   if [ ! -z "$1" ]; then
     echo $1 | grep "[^0-9]" >/dev/null 2>&1
     if [ $? -gt 0 ]; then


### PR DESCRIPTION
First send the shutdown signal to tomcat, if it doesn't stop continue the kill iteration for 10 times/seconds
